### PR TITLE
Update urls to use new org name: amzn -> amazon-ion.

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,9 +1,9 @@
 <footer class="site-footer">
   <div class="wrapper">
     <p>
-      <a href="http://amzn.github.io/ion-docs">Ion</a>
-      | <a href="http://amzn.github.io/ion-hash">Ion Hash</a>
-      | <a href="http://amzn.github.io/ion-schema">Ion Schema</a>
+      <a href="https://amazon-ion.github.io/ion-docs">Ion</a>
+      | <a href="https://amazon-ion.github.io/ion-hash">Ion Hash</a>
+      | <a href="https://amazon-ion.github.io/ion-schema">Ion Schema</a>
     </p>
     <p>
     {% assign year = 'now' | date: "%Y" %}

--- a/_posts/2019-05-23-ion-hash-java-released.md
+++ b/_posts/2019-05-23-ion-hash-java-released.md
@@ -6,5 +6,5 @@ categories: news
 ---
 A reference implementation of the Ion Hash specification is now available as open source software.
 
-| [Ion Hash Reference Implementation](https://github.com/amzn/ion-hash-java) |
+| [Ion Hash Reference Implementation](https://github.com/amazon-ion/ion-hash-java) |
 

--- a/_posts/2019-07-16-ion-hash-python-1_0_1-released.md
+++ b/_posts/2019-07-16-ion-hash-python-1_0_1-released.md
@@ -4,9 +4,9 @@ title: "Ion Hash Python 1.0.1 Released"
 date: 2019-07-16
 categories: news
 ---
-This release is a complete implementation of the [Ion Hash Specification](https://amzn.github.io/ion-hash/docs/spec.html). In addition to low-level `hash_reader`/`hash_writer` APIs, it adds an `ion_hash()` method to all [ion-python](https://github.com/amzn/ion-python) simpleion objects.
+This release is a complete implementation of the [Ion Hash Specification](https://amazon-ion.github.io/ion-hash/docs/spec.html). In addition to low-level `hash_reader`/`hash_writer` APIs, it adds an `ion_hash()` method to all [ion-python](https://github.com/amazon-ion/ion-python) simpleion objects.
 
 This package is available at [PyPI](https://pypi.org/project/ionhash/).
 
-| [Ion Hash Python](https://github.com/amzn/ion-hash-python) |
+| [Ion Hash Python](https://github.com/amazon-ion/ion-hash-python) |
 

--- a/_posts/2019-10-22-ion-hash-python-1_1_0-released.md
+++ b/_posts/2019-10-22-ion-hash-python-1_1_0-released.md
@@ -8,5 +8,5 @@ This release adds support for hashing timestamps with arbitrary precision.
 
 This package is available at [PyPI](https://pypi.org/project/ionhash/).
 
-| [Ion Hash Python](https://github.com/amzn/ion-hash-python) |
+| [Ion Hash Python](https://github.com/amazon-ion/ion-hash-python) |
 

--- a/_posts/2019-11-05-ion-hash-js-1_0_2-released.md
+++ b/_posts/2019-11-05-ion-hash-js-1_0_2-released.md
@@ -4,9 +4,9 @@ title: "Ion Hash JS 1.0.2 Released"
 date: 2019-11-05
 categories: news
 ---
-This release is a complete implementation of the [Ion Hash Specification](https://amzn.github.io/ion-hash/docs/spec.html) for JavaScript, and provides hashing decorators of [ion-js](https://github.com/amzn/ion-js)'s Reader and Writer interfaces.
+This release is a complete implementation of the [Ion Hash Specification](https://amazon-ion.github.io/ion-hash/docs/spec.html) for JavaScript, and provides hashing decorators of [ion-js](https://github.com/amazon-ion/ion-js)'s Reader and Writer interfaces.
 
 This package is available via [NPM](https://www.npmjs.com/package/ion-hash-js).
 
-| [Ion Hash JS](https://github.com/amzn/ion-hash-js) |
+| [Ion Hash JS](https://github.com/amazon-ion/ion-hash-js) |
 

--- a/_posts/2020-03-31-ion-hash-js-2_0-released.md
+++ b/_posts/2020-03-31-ion-hash-js-2_0-released.md
@@ -6,5 +6,5 @@ categories: news ion-hash-js
 ---
 This release introduces a simple API for calculating an Ion hash of any value, including native JavaScript types as well as instances of ion-js 4.0's `dom.Value` class.
 
-| [Release Notes](https://github.com/amzn/ion-hash-js/releases/tag/v2.0.0) | [Ion Hash JS](https://github.com/amzn/ion-hash-js) |
+| [Release Notes](https://github.com/amazon-ion/ion-hash-js/releases/tag/v2.0.0) | [Ion Hash JS](https://github.com/amazon-ion/ion-hash-js) |
 

--- a/_posts/2020-06-04-ion-hash-dotnet-1_0-released.md
+++ b/_posts/2020-06-04-ion-hash-dotnet-1_0-released.md
@@ -8,5 +8,5 @@ This release provides full support for hashing all Ion values.
 
 The Amazon.IonHashDotnet package is available via [NuGet](https://www.nuget.org/packages/Amazon.IonHashDotnet).
 
-| [Release Notes](https://github.com/amzn/ion-hash-dotnet/releases/tag/v1.0.0) | [Ion Hash .NET](https://github.com/amzn/ion-hash-dotnet) |
+| [Release Notes](https://github.com/amazon-ion/ion-hash-dotnet/releases/tag/v1.0.0) | [Ion Hash .NET](https://github.com/amazon-ion/ion-hash-dotnet) |
 

--- a/_posts/2020-09-30-ion-hash-go-1_0-released.md
+++ b/_posts/2020-09-30-ion-hash-go-1_0-released.md
@@ -6,6 +6,6 @@ categories: news ion-hash-go
 ---
 This release provides full support for hashing all Ion values.
 
-The ion-hash-go package is available via [GitHub](https://github.com/amzn/ion-hash-go).
+The ion-hash-go package is available via [GitHub](https://github.com/amazon-ion/ion-hash-go).
 
-| [Release Notes](https://github.com/amzn/ion-hash-go/releases/tag/v1.0.0) | [Ion Hash Go](https://github.com/amzn/ion-hash-go) |
+| [Release Notes](https://github.com/amazon-ion/ion-hash-go/releases/tag/v1.0.0) | [Ion Hash Go](https://github.com/amazon-ion/ion-hash-go) |

--- a/_posts/2021-07-13-ion-hash-go-1_1_2-released.md
+++ b/_posts/2021-07-13-ion-hash-go-1_1_2-released.md
@@ -6,6 +6,6 @@ categories: news ion-hash-go
 ---
 This release updates ion-go to v1.1.3.
 
-The ion-hash-go package is available via [GitHub](https://github.com/amzn/ion-hash-go).
+The ion-hash-go package is available via [GitHub](https://github.com/amazon-ion/ion-hash-go).
 
-| [Release Notes](https://github.com/amzn/ion-hash-go/releases/tag/v1.1.2) | [Ion Hash Go](https://github.com/amzn/ion-hash-go) |
+| [Release Notes](https://github.com/amazon-ion/ion-hash-go/releases/tag/v1.1.2) | [Ion Hash Go](https://github.com/amazon-ion/ion-hash-go) |

--- a/_posts/2021-09-10-ion-hash-python-1_2_1-released.md
+++ b/_posts/2021-09-10-ion-hash-python-1_2_1-released.md
@@ -9,4 +9,4 @@ and adds details to the README's setup instructions.
 
 This package is available at [PyPI](https://pypi.org/project/ionhash/).
 
-| [Release Notes](https://github.com/amzn/ion-hash-python/releases/tag/v1.2.1) | [Ion Hash Python](https://github.com/amzn/ion-hash-python) |
+| [Release Notes](https://github.com/amazon-ion/ion-hash-python/releases/tag/v1.2.1) | [Ion Hash Python](https://github.com/amazon-ion/ion-hash-python) |

--- a/_posts/2022-05-31-ion-hash-dotnet-1_1_1-released.md
+++ b/_posts/2022-05-31-ion-hash-dotnet-1_1_1-released.md
@@ -8,4 +8,4 @@ This release replaces Amazon.IonDotnet version reference with wildcard 1.*
 
 The Amazon.IonHashDotnet package is available via [NuGet](https://www.nuget.org/packages/Amazon.IonHashDotnet).
 
-| [Release Notes](https://github.com/amzn/ion-hash-dotnet/releases/tag/v1.1.1) | [Ion Hash .NET](https://github.com/amzn/ion-hash-dotnet) |
+| [Release Notes](https://github.com/amazon-ion/ion-hash-dotnet/releases/tag/v1.1.1) | [Ion Hash .NET](https://github.com/amazon-ion/ion-hash-dotnet) |

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -5,7 +5,7 @@ title: Ion Hash Specification 1.0
 # {{ page.title }}
 
 This specification defines a hash algorithm for the Ion Data Model, as defined
-by the [Amazon Ion Specification](http://amzn.github.io/ion-docs/spec.html) version 1.0.
+by the [Amazon Ion Specification](https://amazon-ion.github.io/ion-docs/spec.html) version 1.0.
 
 ## Algorithm
 
@@ -122,7 +122,7 @@ callers to define the *h(bytes)* function.
 ## Basic Field Formats
 
 Any UInt, Int, VarUInt, or VarInt fields are encoded in the manner
-defined in the [Amazon Ion Binary Encoding](http://amzn.github.io/ion-docs/binary.html)
+defined in the [Amazon Ion Binary Encoding](https://amazon-ion.github.io/ion-docs/binary.html)
 specification with one difference: such fields are encoded in minimal
 fashion. No padding is allowed, and subfields must be be omitted from 
 representations whenever possible.

--- a/index.md
+++ b/index.md
@@ -33,5 +33,5 @@ Visit the [News][2] page for more announcements related to Ion Hash.
 <!-- References -->
 [1]: docs/spec.html
 [2]: news.html
-[3]: https://amzn.github.io/ion-docs/
+[3]: https://amazon-ion.github.io/ion-docs/
 

--- a/libs.md
+++ b/libs.md
@@ -6,9 +6,9 @@ title: Libraries
 
 | Name | Latest Version | Repository |
 |------|----------------|------|
-| ion-hash-dotnet | [1.1.1](https://github.com/amzn/ion-hash-dotnet/releases/latest) (May 31, 2022) | [Link](https://github.com/amzn/ion-hash-dotnet) |
-| ion-hash-go | [1.1.2](https://github.com/amzn/ion-hash-go/releases/latest) (July 13, 2021) | [Link](https://github.com/amzn/ion-hash-go) |
-| ion-hash-java | [1.0.0](https://github.com/amzn/ion-hash-java/releases/latest) (May 23, 2019) | [Link](https://github.com/amzn/ion-hash-java) |
-| ion-hash-js | [2.0.0](https://github.com/amzn/ion-hash-js/releases/latest) (March 31, 2020) | [Link](https://github.com/amzn/ion-hash-js) |
-| ion-hash-python | [1.2.1](https://github.com/amzn/ion-hash-python/releases/latest) (September 10, 2021) | [Link](https://github.com/amzn/ion-hash-python) |
-| ion-hash-rust | Alpha | [Link](https://github.com/amzn/ion-rust/tree/main/ion-hash) |
+| ion-hash-dotnet | [1.1.1](https://github.com/amazon-ion/ion-hash-dotnet/releases/latest) (May 31, 2022) | [Link](https://github.com/amazon-ion/ion-hash-dotnet) |
+| ion-hash-go | [1.1.2](https://github.com/amazon-ion/ion-hash-go/releases/latest) (July 13, 2021) | [Link](https://github.com/amazon-ion/ion-hash-go) |
+| ion-hash-java | [1.0.0](https://github.com/amazon-ion/ion-hash-java/releases/latest) (May 23, 2019) | [Link](https://github.com/amazon-ion/ion-hash-java) |
+| ion-hash-js | [2.0.0](https://github.com/amazon-ion/ion-hash-js/releases/latest) (March 31, 2020) | [Link](https://github.com/amazon-ion/ion-hash-js) |
+| ion-hash-python | [1.2.1](https://github.com/amazon-ion/ion-hash-python/releases/latest) (September 10, 2021) | [Link](https://github.com/amazon-ion/ion-hash-python) |
+| ion-hash-rust | Alpha | [Link](https://github.com/amazon-ion/ion-rust/tree/main/ion-hash) |


### PR DESCRIPTION
### Issue #, if available:
N/A
### Description of changes:
This PR updated the urls to use new org name: amzn --> amazon-ion.

_**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**_
